### PR TITLE
docs: add immutable releases badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Azure DevOps Commit/PR Validator and Commit+Pull Request Linker Action
 
 [![GitHub release](https://img.shields.io/github/release/joshjohanning/azdo_commit_message_validator.svg?logo=github&labelColor=333)](https://github.com/joshjohanning/azdo_commit_message_validator/releases)
+[![Immutable releases](https://img.shields.io/badge/releases-immutable-blue?labelColor=333)](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases)
 [![GitHub marketplace](https://img.shields.io/badge/marketplace-Azure%20DevOps%20Commit%20Validator%20and%20Pull%20Request%20Linker-blue?logo=github&labelColor=333)](https://github.com/marketplace/actions/azure-devops-commit-validator-and-pull-request-linker)
 [![CI](https://github.com/joshjohanning/azdo_commit_message_validator/actions/workflows/ci.yml/badge.svg)](https://github.com/joshjohanning/azdo_commit_message_validator/actions/workflows/ci.yml)
 [![Publish GitHub Action](https://github.com/joshjohanning/azdo_commit_message_validator/actions/workflows/publish.yml/badge.svg)](https://github.com/joshjohanning/azdo_commit_message_validator/actions/workflows/publish.yml)


### PR DESCRIPTION
Add the [immutable releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases) badge to the README, consistent with the other JS actions in the suite.
